### PR TITLE
Cargo.toml: allow users to specify tls implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ educe = { version = "0.5", default-features = false, features = ["Debug"] }
 futures = "0.3"
 http = "1"
 jsonwebtoken = "9"
-reqwest = { version = "0.11", features = ["json", "serde_json"] }
+reqwest = { version = "0.11", features = ["json", "serde_json"], default-features = false }
 serde = "1"
 serde_json = "1"
 serde_with = "3"
@@ -32,3 +32,8 @@ try-again = "0.1"
 typed-builder = "0.18"
 url = "2"
 uuid = { version = "1", features = ["v7"] }
+
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls", "reqwest/rustls-tls"]


### PR DESCRIPTION
We allow the user to choose between the default
native-tls and rustls TLS implementations for the
reqwest dependency. The default behaviour remains
activating the previously used, default native-tls implementation, thus not breaking any clients.